### PR TITLE
Store/Restore REQ/RES objects

### DIFF
--- a/lib/python-function.js
+++ b/lib/python-function.js
@@ -66,6 +66,14 @@ module.exports = function (RED) {
           }
       }
       if (msgCount>0) {
+          // Restore REQ object if it exists.
+          if (self.req !== undefined){
+            msgs[0].req = self.req;
+          }
+          // Restore RES object if it exists.
+          if (self.res !== undefined){
+            msgs[0].res = self.res;
+          }
           self.send(msgs);
       }
   }
@@ -148,6 +156,14 @@ while True:
     };
     spawnFn(self);
     self.on('input', function(msg) {
+      // Save REQ object if it exists.
+      if (msg.req !== undefined){
+        self.req = msg.req;
+      }
+      // Save RES object if it exists.
+      if (msg.res !== undefined){
+        self.res = msg.res;
+      }
       var cache = [];
       jsonMsg = JSON.stringify(msg, function(key, value) {
           if (typeof value === 'object' && value !== null) {


### PR DESCRIPTION
Added support for HTTP response nodes. Previously, the RES/REQ objects were dropped, preventing the HTTP response node from functioning. This stores and restores the RES/REQ objects within the Python node so that the response can be properly returned.